### PR TITLE
Fix to work with older Xcode if Xcode 6 cannot be found

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,16 @@
 # Clutch xcodebuild script
 # Credits to Tatsh
 
-# Default Xcode
-#BUILD=$(which xcodebuild)
-SDK="iphoneos7.1"
+# Prefer Xcode 6
+[ -d '/Applications/Xcode6-Beta.app' ] && \
+    BUILD='/Applications/Xcode6-Beta.app/Contents/Developer/usr/bin/xcodebuild' && \
+    SDK='iphoneos8.0'
 
-# Xcode6-Beta
-BUILD="/Applications/Xcode6-Beta.app/Contents/Developer/usr/bin/xcodebuild"
-SDK="iphoneos8.0"
+# Default Xcode
+if [ -z "$BUILD" ]; then
+    BUILD=$(which xcodebuild)
+    SDK='iphoneos7.1'
+fi
 
 $BUILD clean install
 


### PR DESCRIPTION
I do not have Xcode 6 installed, so the current build script would never work for me.
