### PR TITLE
Remove Warnings. Some would cuase UB.

### DIFF
--- a/Clutch/Binary.h
+++ b/Clutch/Binary.h
@@ -29,6 +29,6 @@
 @property (readonly) BOOL hasMultipleARMSlices;
 @property (readonly) BOOL hasMultipleARM64Slices;
 
-- (instancetype)initWithBundle:(ClutchBundle *)bundle NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBundle:(ClutchBundle *)bundle;
 
 @end

--- a/Clutch/BundleDumpOperation.h
+++ b/Clutch/BundleDumpOperation.h
@@ -12,6 +12,6 @@
 
 @interface BundleDumpOperation : NSOperation
 
-- (instancetype)initWithBundle:(ClutchBundle *)application NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBundle:(ClutchBundle *)application;
 
 @end

--- a/Clutch/ClutchBundle.m
+++ b/Clutch/ClutchBundle.m
@@ -31,6 +31,7 @@
     _executable = [[Binary alloc]initWithBundle:self];
 
     VERBOSE(@"Preparing to dump %@", _executable);
+	VERBOSE(@"Path: %@", self.executable.binaryPath);
     
     // experimental
     NSMutableData *data = [NSMutableData dataWithContentsOfFile:self.executable.binaryPath];

--- a/Clutch/Dumper.h
+++ b/Clutch/Dumper.h
@@ -31,7 +31,7 @@ void _kill(pid_t pid);
 + (NSString *)readableArchFromMachHeader:(struct mach_header)header;
 - (pid_t)posix_spawn:(NSString *)binaryPath disableASLR:(BOOL)yrn;
 - (pid_t)posix_spawn:(NSString *)binaryPath disableASLR:(BOOL)yrn suspend:(BOOL) suspend;
-- (instancetype)initWithHeader:(thin_header)macho originalBinary:(Binary *)binary NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithHeader:(thin_header)macho originalBinary:(Binary *)binary;
 - (ArchCompatibility)compatibilityMode;
 
 - (void)swapArch;

--- a/Clutch/Dumper.m
+++ b/Clutch/Dumper.m
@@ -17,10 +17,9 @@
 #endif
 
 @implementation Dumper
-
 - (instancetype)initWithHeader:(thin_header)macho originalBinary:(Binary *)binary {
-    
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         _thinHeader = macho;
         _originalBinary = binary;
         _shouldDisableASLR = NO;
@@ -116,7 +115,7 @@
 
 - (cpu_type_t)supportedCPUType
 {
-    return NULL;
+    return 0;
 }
 
 - (BOOL)dumpBinary

--- a/Clutch/FinalizeDumpOperation.h
+++ b/Clutch/FinalizeDumpOperation.h
@@ -15,6 +15,6 @@
 @property (assign) BOOL onlyBinaries;
 @property (assign) NSInteger expectedBinariesCount;
 
-- (instancetype)initWithApplication:(Application *)application NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithApplication:(Application *)application;
 
 @end

--- a/Clutch/FinalizeDumpOperation.m
+++ b/Clutch/FinalizeDumpOperation.m
@@ -75,7 +75,7 @@
         
         if (_onlyBinaries) {
             
-            NSDirectoryEnumerator *dirEnumerator = [NSFileManager.defaultManager enumeratorAtURL:[NSURL fileURLWithPath:_application.workingPath] includingPropertiesForKeys:@[NSURLNameKey,NSURLIsDirectoryKey] options:nil errorHandler:^BOOL(NSURL *url, NSError *error) {
+            NSDirectoryEnumerator *dirEnumerator = [NSFileManager.defaultManager enumeratorAtURL:[NSURL fileURLWithPath:_application.workingPath] includingPropertiesForKeys:@[NSURLNameKey,NSURLIsDirectoryKey] options:0 errorHandler:^BOOL(NSURL *url, NSError *error) {
                 return YES;
             }];
             
@@ -123,7 +123,7 @@
             [_archive CreateZipFile2:[_application.workingPath stringByAppendingPathComponent:_zipFilename] append:YES];
         }
         
-        NSDirectoryEnumerator *dirEnumerator = [NSFileManager.defaultManager enumeratorAtURL:[NSURL fileURLWithPath:_application.workingPath] includingPropertiesForKeys:@[NSURLNameKey,NSURLIsDirectoryKey] options:nil errorHandler:^BOOL(NSURL *url, NSError *error) {
+        NSDirectoryEnumerator *dirEnumerator = [NSFileManager.defaultManager enumeratorAtURL:[NSURL fileURLWithPath:_application.workingPath] includingPropertiesForKeys:@[NSURLNameKey,NSURLIsDirectoryKey] options:0 errorHandler:^BOOL(NSURL *url, NSError *error) {
             return YES;
         }];
         

--- a/Clutch/Framework64Dumper.m
+++ b/Clutch/Framework64Dumper.m
@@ -191,7 +191,7 @@
         [NSString stringWithFormat:@"%u",_thinHeader.offset].UTF8String,
         bundle.parentBundle.bundleIdentifier.UTF8String,
         [NSString stringWithFormat:@"%u",CFSwapInt32(directory.hashOffset)].UTF8String,
-        [NSString stringWithFormat:@"%u",begin].UTF8String,
+        [NSString stringWithFormat:@"%u",(unsigned int)begin].UTF8String,
         [NSString stringWithFormat:@"%u", crypt.cryptoff].UTF8String,
         [NSString stringWithFormat:@"%u", crypt.cryptsize].UTF8String,
         [NSString stringWithFormat:@"%u", cryptlc_offset].UTF8String,
@@ -235,6 +235,7 @@
         dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
         
         dispatch_sync(queue, ^{
+			int dumpResult = 0;
             kill(pid, SIGCONT);
             if (waitpid(pid, &dumpResult, 0) != -1) {
                 DumperLog(@"Success! Child exited with status %u", dumpResult);

--- a/Clutch/FrameworkDumper.m
+++ b/Clutch/FrameworkDumper.m
@@ -201,7 +201,7 @@
         [NSString stringWithFormat:@"%u",_thinHeader.offset].UTF8String,
         bundle.parentBundle.bundleIdentifier.UTF8String,
         [NSString stringWithFormat:@"%u",CFSwapInt32(directory.hashOffset)].UTF8String,
-        [NSString stringWithFormat:@"%u",begin].UTF8String,
+        [NSString stringWithFormat:@"%u",(unsigned int)begin].UTF8String,
         [NSString stringWithFormat:@"%u", crypt.cryptoff].UTF8String,
         [NSString stringWithFormat:@"%u", crypt.cryptsize].UTF8String,
         [NSString stringWithFormat:@"%u", cryptlc_offset].UTF8String,
@@ -222,7 +222,7 @@
           [NSString stringWithFormat:@"%u", crypt.cryptsize].UTF8String,
           [NSString stringWithFormat:@"%u", cryptlc_offset].UTF8String);
     
-    DumperDebugLog(@"hello potato posix_spawn %@", [[NSString alloc] initWithUTF8String:argv]);
+    DumperDebugLog(@"hello potato posix_spawn %@", [[NSString alloc] initWithUTF8String:argv[0]]);
 
     
     posix_spawnattr_init (&attr);
@@ -248,6 +248,7 @@
         
         dispatch_sync(queue, ^{
             kill(pid, SIGCONT);
+			int dumpResult = 0;
             if (waitpid(pid, &dumpResult, 0) != -1) {
                 DumperDebugLog(@"Success! Child exited with status %u", dumpResult);
             } else {

--- a/Clutch/ZipOperation.m
+++ b/Clutch/ZipOperation.m
@@ -91,7 +91,7 @@
             // [_archive addFileToZip:[_application.bundleContainerURL URLByAppendingPathComponent:@"iTunesMetadata.plist" isDirectory:NO].path newname:@"iTunesMetadata.plist"];
         }
         
-        NSDirectoryEnumerator *dirEnumerator = [NSFileManager.defaultManager enumeratorAtURL:_application.bundleURL includingPropertiesForKeys:@[NSURLNameKey,NSURLIsDirectoryKey] options:nil errorHandler:^BOOL(NSURL *url, NSError *error) {
+        NSDirectoryEnumerator *dirEnumerator = [NSFileManager.defaultManager enumeratorAtURL:_application.bundleURL includingPropertiesForKeys:@[NSURLNameKey,NSURLIsDirectoryKey] options:0 errorHandler:^BOOL(NSURL *url, NSError *error) {
             return YES;
         }];
         

--- a/Clutch/progressbar.c
+++ b/Clutch/progressbar.c
@@ -124,7 +124,7 @@ static int progressbar_max(int x, int y) {
 static unsigned int get_screen_width(void) {
   /*char termbuf[2048];
   if (tgetent(termbuf, getenv("TERM")) >= 0) {
-    return tgetnum("co") /* -2;
+    return tgetnum("co")  -2;
   } else {
     return DEFAULT_SCREEN_WIDTH;
   }*/


### PR DESCRIPTION
remove warnings when building with xocde 7.1 on osx 10.11.3 (EI capitan).
some of the old code could cause undefined behavior when running.