### PR TITLE
Fix wrong binary path on iOS 9.2 and above

### DIFF
--- a/Clutch/BundleDumpOperation.m
+++ b/Clutch/BundleDumpOperation.m
@@ -269,13 +269,13 @@
         {
             NSString *_localPath = [originalBinary.binaryPath stringByReplacingOccurrencesOfString:_application.bundleContainerURL.path withString:@""];
             
-            _localPath = [_application.zipPrefix stringByAppendingPathComponent:_localPath];
-            
             //Move binary to correct path on iOS 9.2+
-            if ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/containers/Bundle/Application/"]) {
-                NSArray* pathArray = [_localPath componentsSeparatedByString:@"/"];
-                 _localPath = [NSString stringWithFormat:@"%@/%@/%@",pathArray[0],pathArray[6],pathArray[7]];
+            if ([_application.bundleContainerURL.path hasPrefix:@"/private/var/containers/Bundle/Application/"]) {
+                NSString* iOS92BundleContainerURL = [_application.bundleContainerURL.path stringByReplacingOccurrencesOfString:@"/private" withString:@""];
+                _localPath = [originalBinary.binaryPath stringByReplacingOccurrencesOfString:iOS92BundleContainerURL withString:@""];
             }
+            
+            _localPath = [_application.zipPrefix stringByAppendingPathComponent:_localPath];
             
             [@{_binaryDumpPath:_localPath} writeToFile:[originalBinary.workingPath stringByAppendingPathComponent:@"filesToAdd.plist"] atomically:YES];
         }

--- a/Clutch/BundleDumpOperation.m
+++ b/Clutch/BundleDumpOperation.m
@@ -271,7 +271,7 @@
             
             //Move binary to correct path on iOS 9.2+
             if ([_application.bundleContainerURL.path hasPrefix:@"/private/var/containers/Bundle/Application/"]) {
-                NSString* iOS92BundleContainerURL = [_application.bundleContainerURL.path stringByReplacingOccurrencesOfString:@"/private" withString:@""];
+                NSString *iOS92BundleContainerURL = [_application.bundleContainerURL.path stringByReplacingOccurrencesOfString:@"/private" withString:@""];
                 _localPath = [originalBinary.binaryPath stringByReplacingOccurrencesOfString:iOS92BundleContainerURL withString:@""];
             }
             

--- a/Clutch/BundleDumpOperation.m
+++ b/Clutch/BundleDumpOperation.m
@@ -271,6 +271,12 @@
             
             _localPath = [_application.zipPrefix stringByAppendingPathComponent:_localPath];
             
+            //Move binary to correct path on iOS 9.2+
+            if ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/containers/Bundle/Application/"]) {
+                NSArray* pathArray = [_localPath componentsSeparatedByString:@"/"];
+                 _localPath = [NSString stringWithFormat:@"%@/%@/%@",pathArray[0],pathArray[6],pathArray[7]];
+            }
+            
             [@{_binaryDumpPath:_localPath} writeToFile:[originalBinary.workingPath stringByAppendingPathComponent:@"filesToAdd.plist"] atomically:YES];
         }
         


### PR DESCRIPTION
On iOS 9.2 (?) and above, App bundle moved to `/var/containers/Bundle/Application/`.
This commit fix the bug that Clutch would put binary to `Payload/var/containers/Bundle/Application/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/SomeApps.app/SomeApps`