### PR TITLE
Close stdin/stdout/stderr handles on child processes

### DIFF
--- a/Clutch/Application.h
+++ b/Clutch/Application.h
@@ -20,6 +20,6 @@
 @property (readonly) NSArray *frameworks;
 @property (readonly) NSArray *watchOSApps;
 
-- (void)dumpToDirectoryURL:(NSURL *)directoryURL onlyBinaries:(BOOL)yrn;
+- (BOOL)dumpToDirectoryURL:(NSURL *)directoryURL onlyBinaries:(BOOL)yrn;
 
 @end

--- a/Clutch/Application.m
+++ b/Clutch/Application.m
@@ -29,10 +29,10 @@
 - (instancetype)initWithBundleInfo:(NSDictionary *)info
 {
     if (self = [super initWithBundleInfo:info]) {
-        
+
         _workingUUID = [NSUUID new];
         _workingPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[@"clutch" stringByAppendingPathComponent:_workingUUID.UUIDString]];
-        
+
         [self reloadFrameworksInfo];
         [self reloadPluginsInfo];
         [self reloadWatchOSAppsInfo];
@@ -43,13 +43,13 @@
 
 - (void)prepareForDump {
     [super prepareForDump];
-    
+
     for (ClutchBundle *bundle in _frameworks)
         [bundle prepareForDump];
-    
+
     for (ClutchBundle *bundle in _extensions)
         [bundle prepareForDump];
-    
+
 #ifdef DEBUG
     for (Application *bundle in _watchOSApps) {
         for (ClutchBundle *_watchOSApp in bundle.extensions) {
@@ -57,13 +57,13 @@
         }
     }
 #endif
-    
+
 }
 
 - (BOOL)isAppleWatchApp {
     if ([self.infoDictionary[@"CFBundleSupportedPlatforms"] containsObject:@"WatchOS"] || [self.infoDictionary[@"DTPlatformName"] isEqualToString:@"watchos"])
         return  YES;
-    
+
     return NO;
 }
 
@@ -71,11 +71,11 @@
 {
     _hasAppleWatchApp = NO;
     _watchOSApps = [NSMutableArray new];
-    
+
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL *directoryURL = [NSURL fileURLWithPath:[self.bundlePath stringByAppendingPathComponent:@"Watch"]]; // URL pointing to the directory you want to browse
     NSArray *keys = @[NSURLIsDirectoryKey];
-    
+
     NSDirectoryEnumerator *enumerator = [fileManager
                                          enumeratorAtURL:directoryURL
                                          includingPropertiesForKeys:keys
@@ -85,11 +85,11 @@
                                              // Return YES if the enumeration should continue after the error.
                                              return YES;
                                          }];
-    
+
     for (NSURL *url in enumerator) {
         NSError *error;
         NSNumber *isDirectory = nil;
-        
+
         if (! [url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
             // handle error
         }
@@ -97,7 +97,7 @@
         {
             Application *watchOSApp = [[Application alloc]initWithBundleInfo:@{@"BundleContainer":url.URLByDeletingLastPathComponent,
                                                                      @"BundleURL":url}];
-            
+
             if (watchOSApp.isAppleWatchApp) {
                 _hasAppleWatchApp = YES;
                 watchOSApp.parentBundle = self;
@@ -111,11 +111,11 @@
 - (void)reloadFrameworksInfo
 {
     _frameworks = [NSMutableArray new];
-    
+
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL *directoryURL = [NSURL fileURLWithPath:self.privateFrameworksPath]; // URL pointing to the directory you want to browse
     NSArray *keys = @[NSURLIsDirectoryKey];
-    
+
     NSDirectoryEnumerator *enumerator = [fileManager
                                          enumeratorAtURL:directoryURL
                                          includingPropertiesForKeys:keys
@@ -125,11 +125,11 @@
                                              // Return YES if the enumeration should continue after the error.
                                              return YES;
                                          }];
-    
+
     for (NSURL *url in enumerator) {
         NSError *error;
         NSNumber *isDirectory = nil;
-        
+
         if (! [url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
             // handle error
         }
@@ -138,9 +138,9 @@
             Framework *fmwk = [[Framework alloc]initWithBundleInfo:@{@"BundleContainer":url.URLByDeletingLastPathComponent,
                                                                      @"BundleURL":url}];
             if (fmwk) {
-                
+
                 fmwk.parentBundle = self;
-                
+
                 [_frameworks addObject:fmwk];
             }
         }
@@ -150,11 +150,11 @@
 - (void)reloadPluginsInfo
 {
     _extensions = [NSMutableArray new];
-    
+
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL *directoryURL = [NSURL fileURLWithPath:self.builtInPlugInsPath]; // URL pointing to the directory you want to browse
     NSArray *keys = @[NSURLIsDirectoryKey];
-    
+
     NSDirectoryEnumerator *enumerator = [fileManager
                                          enumeratorAtURL:directoryURL
                                          includingPropertiesForKeys:keys
@@ -164,11 +164,11 @@
                                              // Return YES if the enumeration should continue after the error.
                                              return YES;
                                          }];
-    
+
     for (NSURL *url in enumerator) {
         NSError *error;
         NSNumber *isDirectory = nil;
-        
+
         if (! [url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
             // handle error
         }
@@ -177,7 +177,7 @@
             Extension *_extension = [[Extension alloc]initWithBundleInfo:@{@"BundleContainer":url.URLByDeletingLastPathComponent,
                                                                            @"BundleURL":url}];
             if (_extension) {
-                
+
                 _extension.parentBundle = self;
                 [_extensions addObject:_extension];
             }
@@ -185,29 +185,29 @@
     }
 }
 
-- (void)dumpToDirectoryURL:(NSURL *)directoryURL onlyBinaries:(BOOL)_onlyBinaries
+- (BOOL)dumpToDirectoryURL:(NSURL *)directoryURL onlyBinaries:(BOOL)_onlyBinaries
 {
     [super dumpToDirectoryURL:directoryURL];
-    
+
     [self prepareForDump];
-        
+
     [[NSFileManager defaultManager]createDirectoryAtPath:_workingPath withIntermediateDirectories:YES attributes:nil error:nil];
-        
+
     ZipOperation *_mainZipOperation = [[ZipOperation alloc]initWithApplication:self];
-    
+
     BundleDumpOperation *_dumpOperation = self.executable.dumpOperation;
-    
+
     FinalizeDumpOperation *_finalizeDumpOperation = [[FinalizeDumpOperation alloc]initWithApplication:self];
     _finalizeDumpOperation.onlyBinaries = _onlyBinaries;
-    
+
     if (!_onlyBinaries)
     [_finalizeDumpOperation addDependency:_mainZipOperation];
-    
+
     [_finalizeDumpOperation addDependency:_dumpOperation];
-    
+
     NSMutableArray *_additionalDumpOpeartions = ({
       NSMutableArray *array =  [NSMutableArray new];
-       
+
 #ifdef DEBUG
         for (Application *_application in self.watchOSApps) {
             for (Extension *_extension in _application.extensions) {
@@ -216,102 +216,100 @@
             }
         }
 #endif
-        
+
         for (Framework *_framework in self.frameworks) {
             [array addObject:_framework.executable.dumpOperation];
         }
-        
+
         for (Extension *_extension in self.extensions) {
             [array addObject:_extension.executable.dumpOperation];
         }
         array;
     });
-    
+
     _finalizeDumpOperation.expectedBinariesCount = _additionalDumpOpeartions.count + 1;
-    
+
     NSMutableArray *_additionalZipOpeartions = ({
-        
+
         NSMutableArray *array =  [NSMutableArray new];
-        
+
 #ifdef DEBUG
         for (Application *_application in self.watchOSApps) {
             for (Extension *_extension in _application.extensions) {
                 ZipOperation *_zipOperation = [[ZipOperation alloc]initWithApplication:_extension];
                 [_zipOperation addDependency:_mainZipOperation];
-                
+
                 [array addObject:_zipOperation];
             }
         }
 #endif
-        
+
         for (Framework *_framework in self.frameworks) {
             ZipOperation *_zipOperation = [[ZipOperation alloc]initWithApplication:_framework];
             [_zipOperation addDependency:_mainZipOperation];
-            
+
             [array addObject:_zipOperation];
         }
-        
+
         for (Extension *_extension in self.extensions) {
             ZipOperation *_zipOperation = [[ZipOperation alloc]initWithApplication:_extension];
             [_zipOperation addDependency:_mainZipOperation];
-            
+
             [array addObject:_zipOperation];
         }
         array;
     });
-    
+
     if (_onlyBinaries)
         [_additionalZipOpeartions removeAllObjects];
-    
+
     for (int i=1; i<_additionalZipOpeartions.count;i++) {
         ZipOperation *_zipOperation = _additionalZipOpeartions[i];
         [_zipOperation addDependency:_additionalZipOpeartions[i-1]];
     }
-    
+
     for (NSOperation *operation in _additionalDumpOpeartions) {
         [_finalizeDumpOperation addDependency:operation];
     }
-    
+
     if (_additionalZipOpeartions.lastObject) {
         [_finalizeDumpOperation addDependency:_additionalZipOpeartions.lastObject];
     }
 
     if (!_onlyBinaries)
         [_dumpQueue addOperation:_mainZipOperation];
-    
+
     [_dumpQueue addOperation:_dumpOperation];
-    
+
     for (NSOperation *operation in _additionalDumpOpeartions) {
         [_dumpQueue addOperation:operation];
     }
-    
+
     for (NSOperation *operation in _additionalZipOpeartions) {
         [_dumpQueue addOperation:operation];
     }
-    
+
     [_dumpQueue addOperation:_finalizeDumpOperation];
+    BOOL failed = NO;
 
-    // Kill output (example use case is remote SSH without TTY), #
-    // Still provide IPA path or working path as output
-    // FIXME: Find the correct solution to fclose(stdout/stderr) when not in a TTY for sshd
-    // http://www.snailbook.com/faq/background-jobs.auto.html
-    // Theory: this may be caused by the many threads launched by NSOperation that also print. Perhaps forcing all prints to be on the main thread is the solution?
-    if (!isatty(1) || !isatty(2)) {
-        if (!_onlyBinaries) {
-            NSString *dumpedPath = @"/private/var/mobile/Documents/Dumped";
-            [[ClutchPrint sharedInstance] print:[dumpedPath stringByAppendingPathComponent:self.zipFilename]];
-        } else {
-            [[ClutchPrint sharedInstance] print:self.workingPath];
+    while (_dumpQueue.operationCount > 0) {
+        for (NSOperation *op in _dumpQueue.operations) {
+            if ([op isKindOfClass:[BundleDumpOperation class]]) {
+                BundleDumpOperation *op2 = (BundleDumpOperation *)op;
+                if (op2.failed) {
+                    failed = YES;
+                    break;
+                }
+            }
         }
-        fflush(stdout);
-        fflush(stderr);
-
-        fclose(stdin);
-        fclose(stdout);
-        fclose(stderr);
+    }
+    if (failed) {
+        [_dumpQueue cancelAllOperations];
     }
 
     [_dumpQueue waitUntilAllOperationsAreFinished];
+
+    return !failed;
 }
 
 - (NSString *)zipFilename

--- a/Clutch/BundleDumpOperation.h
+++ b/Clutch/BundleDumpOperation.h
@@ -11,6 +11,7 @@
 @class ClutchBundle;
 
 @interface BundleDumpOperation : NSOperation
+@property (assign) BOOL failed;
 
 - (instancetype)initWithBundle:(ClutchBundle *)application;
 

--- a/Clutch/BundleDumpOperation.m
+++ b/Clutch/BundleDumpOperation.m
@@ -20,7 +20,7 @@
 @interface BundleDumpOperation ()
 {
     ClutchBundle *_application;
-    BOOL _executing, _finished;
+    BOOL _executing, _finished, failed;
     NSString *_binaryDumpPath;
 }
 
@@ -29,8 +29,10 @@
 @end
 
 @implementation BundleDumpOperation
+@synthesize failed;
 
 -(void)failedOperation {
+    self.failed = YES;
     NSLog(@"failed operation :(");
     NSLog(@"application %@", _application->_dumpQueue);
     NSArray* wow = [_application->_dumpQueue operations];
@@ -76,11 +78,11 @@
         [self didChangeValueForKey:@"isFinished"];
         return;
     }
-    
+
     self.completionBlock = ^{
-        
+
     };
-    
+
     // If the operation is not canceled, begin executing the task.
     [self willChangeValueForKey:@"isExecuting"];
     [NSThread detachNewThreadSelector:@selector(main) toTarget:self withObject:nil];
@@ -92,57 +94,57 @@
 
 - (void)main {
     @try {
-        
+
         NSFileManager *_fileManager = [NSFileManager defaultManager];
-        
+
         Binary *originalBinary = _application.executable;
-        
+
         _binaryDumpPath = [originalBinary.workingPath stringByAppendingPathComponent:originalBinary.binaryPath.lastPathComponent];
-        
+
         [_fileManager createDirectoryAtPath:_binaryDumpPath.stringByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:nil];
-        
+
         //if (![_application isKindOfClass:[Framework class]])
         [_fileManager copyItemAtPath:originalBinary.binaryPath toPath:_binaryDumpPath error:nil];
-                
+
         NSFileHandle *tmpHandle = [[NSFileHandle alloc]initWithFileDescriptor:fileno(fopen(originalBinary.binaryPath.UTF8String, "r+")) closeOnDealloc:YES];
-        
+
         NSData *headersData = tmpHandle.availableData;
-        
+
         [tmpHandle closeFile];
-        
+
         if (!headersData) {
             gbprintln(@"Failed to extract headers info from binary %@.",originalBinary);
             [self failedOperation];
             return;
         }
-        
+
         thin_header headers[4];
         uint32_t numHeaders = 0;
-        
+
         headersFromBinary(headers, headersData, &numHeaders);
-        
-        
+
+
         if (numHeaders == 0) {
             gbprintln(@"No compatible architecture found");
         }
-        
+
         BOOL isFAT = numHeaders > 1;
-        
+
         uint32_t dumpCount = 0;
-        
+
         NSMutableArray *_headersToStrip = [NSMutableArray new];
-        
+
         NSArray *dumpers = [_application isKindOfClass:[Framework class]] ? [self.class availableFrameworkDumpers]: [self.class availableDumpers];
-        
+
         for (uint32_t i = 0; i < numHeaders; i++) {
-            
+
             thin_header macho = headers[i];
             Dumper<BinaryDumpProtocol> *_dumper = nil;
-            
+
             [[ClutchPrint sharedInstance] printDeveloper:@"Finding compatible dumper for binary %@ with arch cputype: %u", originalBinary, macho.header.cputype];
             for (Class dumperClass in dumpers) {
                 _dumper = [[dumperClass alloc]initWithHeader:macho originalBinary:originalBinary];
-                
+
                 if ([_dumper compatibilityMode] == ArchCompatibilityNotCompatible) {
                     [[ClutchPrint sharedInstance] printDeveloper:@"%@ cannot dump binary %@ (arch %@). Dumper not compatible, finding another dumper",_dumper,originalBinary,[Dumper readableArchFromHeader:macho]];
                     _dumper = nil;
@@ -150,22 +152,22 @@
                     break;
                 }
             }
-            
+
             if (_dumper == nil) {
                 [[ClutchPrint sharedInstance] printDeveloper:@"Couldn't find compatible dumper for binary %@ with arch %@. Will have to \"strip\".",originalBinary,[Dumper readableArchFromHeader:macho]];
                 [[ClutchPrint sharedInstance] printDeveloper:@"offset %u", macho.offset];
                 [_headersToStrip addObject:[NSNumber numberWithUnsignedInt:macho.offset]];
                 continue;
             }
-            
+
             [[ClutchPrint sharedInstance] printDeveloper:@"Found compatible dumper %@ for binary %@ with arch %@",_dumper,originalBinary,[Dumper readableArchFromHeader:macho]];
-            
+
             NSFileHandle *_handle = [[NSFileHandle alloc]initWithFileDescriptor:fileno(fopen(originalBinary.binaryPath.UTF8String, "r+")) closeOnDealloc:YES];
-            
+
             _dumper.originalFileHandle = _handle;
-            
+
             BOOL result = [_dumper dumpBinary];
-            
+
             if (result == YES) {
                 dumpCount++;
                 [[ClutchPrint sharedInstance] printDeveloper:@"Sucessfully dumped %@ segment of %@", [Dumper readableArchFromHeader:macho], originalBinary];
@@ -173,22 +175,22 @@
                 [[ClutchPrint sharedInstance] printError:@"Failed to dump %@ with arch %@",originalBinary,[Dumper readableArchFromHeader:macho]];
                 [self failedOperation];
             }
-            
+
             [_handle closeFile];
         }
-        
+
         if (!dumpCount) {
             [[ClutchPrint sharedInstance] printError:@"Failed to dump %@", originalBinary];
             [self failedOperation];
-            
+
             return;
         }
-        
-        
+
+
 #pragma mark "stripping" headers in FAT binary
         if ([_headersToStrip count] > 0) {
             NSFileHandle *_dumpHandle = [[NSFileHandle alloc]initWithFileDescriptor:fileno(fopen(_binaryDumpPath.UTF8String, "r+")) closeOnDealloc:YES];
-            
+
             uint32_t magic = [_dumpHandle intAtOffset:0];
             NSData *buffer = [_dumpHandle readDataOfLength:4096];
 
@@ -200,7 +202,7 @@
             NSMutableArray* _headersToKeep = [NSMutableArray new];
             struct fat_header fat = *(struct fat_header *)buffer.bytes;
             fat.nfat_arch = SWAP(fat.nfat_arch);
-            
+
             int offset = sizeof(struct fat_header);
             for (int i = 0; i < fat.nfat_arch; i++) {
                 struct fat_arch arch = *(struct fat_arch *)([buffer bytes] + offset);
@@ -216,9 +218,9 @@
                 }
                 offset += sizeof(struct fat_arch);
             }
-            
+
 #pragma mark lipo ftw
-            
+
             [[NSFileManager defaultManager]moveItemAtPath:_binaryDumpPath toPath:[_binaryDumpPath stringByAppendingPathExtension:@"fatty"] error:nil];
             NSFileHandle *_fattyHandle = [[NSFileHandle alloc]initWithFileDescriptor:fileno(fopen([_binaryDumpPath stringByAppendingPathExtension:@"fatty"].UTF8String, "r+")) closeOnDealloc:YES];
 
@@ -226,64 +228,64 @@
             _dumpHandle = [[NSFileHandle alloc]initWithFileDescriptor:fileno(fopen(_binaryDumpPath.UTF8String, "r+")) closeOnDealloc:YES];
 
             [_dumpHandle replaceBytesInRange:NSMakeRange(0, sizeof(uint32_t)) withBytes:&magic];
-            
+
             //skip 4 bytes for magic, 4 bytes of nfat_arch
             uint32_t nfat_arch = SWAP([_headersToKeep count]);
             [_dumpHandle replaceBytesInRange:NSMakeRange(sizeof(uint32_t), sizeof(uint32_t)) withBytes:&nfat_arch];
             [[ClutchPrint sharedInstance] printDeveloper:@"changing nfat_arch to %u", SWAP(nfat_arch)];
-            
+
             offset = sizeof(struct fat_header);
-            
+
             for (int i = 0,macho_offset = 0; i < _headersToKeep.count; i++) {
                 NSValue* archValue = _headersToKeep[i];
                 struct fat_arch keepArch;
                 [archValue getValue:&keepArch];
                 [[ClutchPrint sharedInstance] printDeveloper:@"headers to keep: %u %u", SWAP(keepArch.cpusubtype), SWAP(keepArch.cputype)];
-                
+
                 int origOffset = SWAP(keepArch.offset);
-                
+
                 if (!macho_offset) {
                     macho_offset =  pow(2.0, SWAP(keepArch.align));
                 }
-                
+
                 keepArch.offset = SWAP(macho_offset);
-                
+
                 [_fattyHandle seekToFileOffset:origOffset];
-                
+
                 NSData *machOData = [_fattyHandle readDataOfLength:SWAP(keepArch.size)];
-                
+
                 [_dumpHandle replaceBytesInRange:NSMakeRange(offset, sizeof(struct fat_arch)) withBytes:&keepArch];
                 [_dumpHandle replaceBytesInRange:NSMakeRange(macho_offset, SWAP(keepArch.size)) withBytes:[machOData bytes]];
                 offset += sizeof(struct fat_arch);
                 macho_offset += SWAP(keepArch.size);
             }
-            
+
             [_dumpHandle closeFile];
             [_fattyHandle closeFile];
-            
+
             [[NSFileManager defaultManager]removeItemAtPath:[_binaryDumpPath stringByAppendingPathExtension:@"fatty"]  error:nil];
 
             [[ClutchPrint sharedInstance] printVerbose:@"Finished 'stripping' binary %@", originalBinary];
             [[ClutchPrint sharedInstance] printVerbose:@"Note: This binary will be missing some undecryptable architectures"];
     }
-        
-        
+
+
 #pragma mark checking if everything's fine
         if (dumpCount == (numHeaders-_headersToStrip.count))
         {
             NSString *_localPath = [originalBinary.binaryPath stringByReplacingOccurrencesOfString:_application.bundleContainerURL.path withString:@""];
-            
+
             //Move binary to correct path on iOS 9.2+
             if ([_application.bundleContainerURL.path hasPrefix:@"/private/var/containers/Bundle/Application/"]) {
                 NSString *iOS92BundleContainerURL = [_application.bundleContainerURL.path stringByReplacingOccurrencesOfString:@"/private" withString:@""];
                 _localPath = [originalBinary.binaryPath stringByReplacingOccurrencesOfString:iOS92BundleContainerURL withString:@""];
             }
-            
+
             _localPath = [_application.zipPrefix stringByAppendingPathComponent:_localPath];
-            
+
             [@{_binaryDumpPath:_localPath} writeToFile:[originalBinary.workingPath stringByAppendingPathComponent:@"filesToAdd.plist"] atomically:YES];
         }
-        
+
         // Do the main work of the operation here.
         [self completeOperation];
     }

--- a/Clutch/main.m
+++ b/Clutch/main.m
@@ -215,6 +215,10 @@ int main (int argc, const char * argv[])
         }
 
         if (dumpedFramework) {
+            fclose(stdin);
+            fclose(stdout);
+            fclose(stderr);
+
             if (successfullyDumpedFramework) {
                 return 0;
             }
@@ -292,7 +296,9 @@ int main (int argc, const char * argv[])
 #endif
 
             gettimeofday(&start, NULL);
-            [_selectedApp dumpToDirectoryURL:nil onlyBinaries:[_selectedOption isEqualToString:@"binary-dump"]];
+            if (![_selectedApp dumpToDirectoryURL:nil onlyBinaries:[_selectedOption isEqualToString:@"binary-dump"]]) {
+                return 1;
+            }
         }
     }
 


### PR DESCRIPTION
Finally figured this out. Also tested on iOS 10.1.1 on iPhone 7 😎 

Fixes #148
Also this restores correct exit codes on failure (`1` on failure, `0` on success)