### PR TITLE
Change binary owner to _installd

### DIFF
--- a/Clutch/Binary.m
+++ b/Clutch/Binary.m
@@ -45,12 +45,6 @@
             _frameworksPath = (_bundle.bundleContainerURL).path;
         }
 
-        // perm. fix
-
-        NSDictionary *ownershipInfo = @{NSFileOwnerAccountName : @"mobile", NSFileGroupOwnerAccountName : @"mobile"};
-
-        [[NSFileManager defaultManager] setAttributes:ownershipInfo ofItemAtPath:self.binaryPath error:nil];
-
         _sinfPath = [_bundle pathForResource:_bundle.executablePath.lastPathComponent
                                       ofType:@"sinf"
                                  inDirectory:@"SC_Info"];

--- a/Clutch/ClutchBundle.m
+++ b/Clutch/ClutchBundle.m
@@ -50,10 +50,6 @@
 
     KJPrintVerbose(@"Preparing to dump %@", _executable);
     KJPrintVerbose(@"Path: %@", self.executable.binaryPath);
-
-    NSDictionary *ownershipInfo = @{NSFileOwnerAccountName : @"mobile", NSFileGroupOwnerAccountName : @"mobile"};
-
-    [[NSFileManager defaultManager] setAttributes:ownershipInfo ofItemAtPath:self.executable.binaryPath error:nil];
 }
 
 - (void)dumpToDirectoryURL:(NSURL *)directoryURL {


### PR DESCRIPTION
Apps are now owned by _installd, not mobile. This fixes a bug where iOS was unable to update apps which had been dumped by Clutch because it didn't have permission to write to those files (see #204).