### PR TITLE
Fixed Xcode build issues

### DIFF
--- a/Clutch/ClutchCommands.m
+++ b/Clutch/ClutchCommands.m
@@ -190,7 +190,7 @@
         [NSMutableString stringWithFormat:@"Usage: %@ [OPTIONS]\n", NSProcessInfo.processInfo.processName];
 
     for (ClutchCommand *command in self.allCommands) {
-        BOOL isInvisible = command.flag & ClutchCommandFlagInvisible;
+        BOOL isInvisible = (command.flag & ClutchCommandFlagInvisible) ? YES : NO;
 
         if (!isInvisible) {
             [helpString appendFormat:@"%-2s %-30s%@\n",

--- a/Clutch/Dumper.m
+++ b/Clutch/Dumper.m
@@ -303,7 +303,7 @@
                 if (curloc >= buf + 0x1000) {
                     // we are currently extended past the header page
                     // offset for the next round:
-                    headerProgress = (((char *)curloc - (char *)buf) % 0x1000);
+                    headerProgress = (uint32_t)(((char *)curloc - (char *)buf) % 0x1000);
                     // prevent attaching overdrive dylib by skipping
                     goto writedata;
                 }


### PR DESCRIPTION
Fixed the following build issues:
1. error: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-conversion]
` headerProgress = (((char *)curloc - (char *)buf) % 0x1000);` 

2. error: implicit conversion from integral type 'int' to 'BOOL' [-Werror,-Wobjc-signed-char-bool-implicit-int-conversion]
`BOOL isInvisible = command.flag & ClutchCommandFlagInvisible;`