### PR TITLE
Set DYLD_FRAMEWORK_PATH when dumping frameworks

### DIFF
--- a/Clutch/Framework64Dumper.m
+++ b/Clutch/Framework64Dumper.m
@@ -154,6 +154,11 @@
     }
 
     [newFileHandle closeFile];
+	
+	// Lazy, but when dumping a framework it may refer to other frameworks by
+	// rpath. Set our own framework path to the app's framework directory so
+	// that these dependent loads will fallback here.
+	setenv("DYLD_FRAMEWORK_PATH", self.originalBinary.frameworksPath.UTF8String, 0);
 
     extern char **environ;
     posix_spawnattr_t attr;

--- a/Clutch/FrameworkDumper.m
+++ b/Clutch/FrameworkDumper.m
@@ -160,6 +160,11 @@
     [newFileHandle closeFile];
 
     KJDebug(@"hello from the other side");
+	
+	// Lazy, but when dumping a framework it may refer to other frameworks by
+	// rpath. Set our own framework path to the app's framework directory so
+	// that these dependent loads will fallback here.
+	setenv("DYLD_FRAMEWORK_PATH", self.originalBinary.frameworksPath.UTF8String, 0);
 
     extern char **environ;
     posix_spawnattr_t attr;


### PR DESCRIPTION
This fixes most issues with frameworks that refer to each other.